### PR TITLE
Build lxrad on Linux using github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build lxrad
+on: [push]
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: sudo apt-get install libwxgtk3.0-gtk3-dev libopenal-dev doxygen
+      - name: Build
+        run: |
+          ./make_deps.sh
+          ./configure
+          make
+


### PR DESCRIPTION
This adds a Github Action building lxrad on Linux.
Actions are set up to run on every push.

Example of action running on [my fork](https://github.com/hsorbo/lxrad/runs/5957510335)